### PR TITLE
Adds a required_providers block with a minimum version for the aws provider

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/accepter/README.md
+++ b/modules/accepter/README.md
@@ -3,13 +3,16 @@
 <!-- BEGIN TFDOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| aws | >= 3.29.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 3.29.0 |
 
 ## Inputs
 

--- a/modules/accepter/versions.tf
+++ b/modules/accepter/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.29.0"
+    }
+  }
+}

--- a/modules/account/README.md
+++ b/modules/account/README.md
@@ -3,13 +3,16 @@
 <!-- BEGIN TFDOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| aws | >= 3.29.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 3.29.0 |
 
 ## Inputs
 

--- a/modules/account/versions.tf
+++ b/modules/account/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.29.0"
+    }
+  }
+}

--- a/modules/action_target/README.md
+++ b/modules/action_target/README.md
@@ -3,13 +3,16 @@
 <!-- BEGIN TFDOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| aws | >= 3.29.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 3.29.0 |
 
 ## Inputs
 

--- a/modules/action_target/versions.tf
+++ b/modules/action_target/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.29.0"
+    }
+  }
+}

--- a/modules/cross-account-member/README.md
+++ b/modules/cross-account-member/README.md
@@ -12,7 +12,6 @@
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.29.0 |
 | aws.administrator | >= 3.29.0 |
 
 ## Inputs

--- a/modules/cross-account-member/main.tf
+++ b/modules/cross-account-member/main.tf
@@ -18,12 +18,8 @@ module "member" {
     aws = aws.administrator
   }
 
-  account_id = data.aws_caller_identity.this.account_id
+  account_id = module.account.account.id
   email      = var.member_email
-
-  depends_on = [
-    module.account
-  ]
 }
 
 # Accept invite
@@ -36,8 +32,6 @@ module "accept" {
     module.member
   ]
 }
-
-data "aws_caller_identity" "this" {}
 
 data "aws_caller_identity" "administrator" {
   provider = aws.administrator

--- a/modules/member/README.md
+++ b/modules/member/README.md
@@ -3,13 +3,16 @@
 <!-- BEGIN TFDOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| aws | >= 3.29.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 3.29.0 |
 
 ## Inputs
 

--- a/modules/member/versions.tf
+++ b/modules/member/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.29.0"
+    }
+  }
+}

--- a/modules/subscriptions/README.md
+++ b/modules/subscriptions/README.md
@@ -3,13 +3,16 @@
 <!-- BEGIN TFDOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| aws | >= 3.29.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 3.29.0 |
 
 ## Inputs
 

--- a/modules/subscriptions/versions.tf
+++ b/modules/subscriptions/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.29.0"
+    }
+  }
+}


### PR DESCRIPTION
This helps resolve warnings in tf 0.15 of the form:

```
Module module.<MODULE> does not declare a provider named aws.
If you wish to specify a provider configuration for the module, add an entry for aws in the required_providers block within the module.
```