### PR TITLE
Updated to use new configuration_aliases tag

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.2
+current_version = 3.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 3.0.0
+
+**Released**: 2022.05.22
+
+**Commit Delta**: [Change from 2.0.2 release](https://github.com/plus3it/terraform-aws-tardigrade-security-hub/compare/2.0.2...3.0.0)
+
+**Summary**:
+
+*   Updated to use new configuration_aliases tag. Also updated the provider profiles names to match the test framework construct.
+
 ### 2.0.2
 
 **Released**: 2021.11.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### 3.0.0
 
-**Released**: 2022.05.22
+**Released**: 2022.05.13
 
 **Commit Delta**: [Change from 2.0.2 release](https://github.com/plus3it/terraform-aws-tardigrade-security-hub/compare/2.0.2...3.0.0)
 

--- a/modules/cross-account-member/main.tf
+++ b/modules/cross-account-member/main.tf
@@ -12,7 +12,7 @@ module "member" {
   source = "../member"
 
   providers = {
-    aws = aws.admin
+    aws = aws.admininstrator
   }
 
   account_id = module.account.account.id

--- a/modules/cross-account-member/main.tf
+++ b/modules/cross-account-member/main.tf
@@ -1,15 +1,6 @@
-# Enables/configures Security Hub in administrator account
-module "securityhub_owner" {
-  source = "../../"
-}
-
 # Enables/configures Security Hub in member account
 module "account" {
   source = "../../"
-
-  providers = {
-    aws = aws.invitee
-  }
 
   action_targets             = var.action_targets
   product_subscription_arns  = var.product_subscription_arns
@@ -20,7 +11,9 @@ module "account" {
 module "member" {
   source = "../member"
 
-  depends_on = [module.securityhub_owner]
+  providers = {
+    aws = aws.admin
+  }
 
   account_id = module.account.account.id
   email      = var.member_email
@@ -31,10 +24,6 @@ module "accept" {
   source = "../accepter"
 
   depends_on = [module.account]
-
-  providers = {
-    aws = aws.invitee
-  }
 
   master_account_id = module.member.member.master_id
 }

--- a/modules/cross-account-member/main.tf
+++ b/modules/cross-account-member/main.tf
@@ -1,10 +1,15 @@
-provider "aws" {
-  alias = "administrator"
+# Enables/configures Security Hub in administrator account
+module "securityhub_owner" {
+  source = "../../"
 }
 
 # Enables/configures Security Hub in member account
 module "account" {
   source = "../../"
+
+  providers = {
+    aws = aws.invitee
+  }
 
   action_targets             = var.action_targets
   product_subscription_arns  = var.product_subscription_arns
@@ -14,9 +19,8 @@ module "account" {
 # Send invite from administrator account
 module "member" {
   source = "../member"
-  providers = {
-    aws = aws.administrator
-  }
+
+  depends_on = [module.securityhub_owner]
 
   account_id = module.account.account.id
   email      = var.member_email
@@ -25,6 +29,12 @@ module "member" {
 # Accept invite
 module "accept" {
   source = "../accepter"
+
+  depends_on = [module.account]
+
+  providers = {
+    aws = aws.invitee
+  }
 
   master_account_id = module.member.member.master_id
 }

--- a/modules/cross-account-member/versions.tf
+++ b/modules/cross-account-member/versions.tf
@@ -5,7 +5,7 @@ terraform {
     aws = {
       source                = "hashicorp/aws"
       version               = ">= 3.29.0"
-      configuration_aliases = [aws.admin]
+      configuration_aliases = [aws.admininstrator]
     }
   }
 }

--- a/modules/cross-account-member/versions.tf
+++ b/modules/cross-account-member/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.29.0"
+      source                = "hashicorp/aws"
+      version               = ">= 3.29.0"
+      configuration_aliases = [aws.invitee]
     }
   }
 }

--- a/modules/cross-account-member/versions.tf
+++ b/modules/cross-account-member/versions.tf
@@ -5,7 +5,7 @@ terraform {
     aws = {
       source                = "hashicorp/aws"
       version               = ">= 3.29.0"
-      configuration_aliases = [aws.invitee]
+      configuration_aliases = [aws.admin]
     }
   }
 }

--- a/tests/securityhub_cross_account/main.tf
+++ b/tests/securityhub_cross_account/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 # Provider to use as the securityhub administrator
 provider "aws" {
   region  = "us-east-1"
-  alias   = "admin"
+  alias   = "admininstrator"
   profile = "awsalternate" # Profile must exist in your .aws/config
 }
 
@@ -16,7 +16,7 @@ module "securityhub_owner" {
   source = "../../"
 
   providers = {
-    aws = aws.admin
+    aws = aws.admininstrator
   }
 }
 
@@ -24,7 +24,7 @@ module "securityhub" {
   source = "../../modules/cross-account-member"
 
   providers = {
-    aws.admin = aws.admin
+    aws.admininstrator = aws.admininstrator
   }
 
   # Without the following line it takes two attepts to destroy the resources created by the test

--- a/tests/securityhub_cross_account/main.tf
+++ b/tests/securityhub_cross_account/main.tf
@@ -1,20 +1,21 @@
+# Provider to use as the securityhub member (aka invitee)
 provider "aws" {
   region  = "us-east-1"
-  profile = "resource-member"
+  alias   = "invitee"
+  profile = "aws" # Profile must exist in your .aws/config
 }
 
+# Provider to use as the securityhub administrator
 provider "aws" {
   region  = "us-east-1"
-  alias   = "resource-owner"
-  profile = "resource-owner"
+  profile = "awsalternate" # Profile must exist in your .aws/config
 }
 
 module "securityhub" {
   source = "../../modules/cross-account-member"
 
   providers = {
-    aws               = aws
-    aws.administrator = aws.resource-owner
+    aws.invitee = aws.invitee
   }
 
   member_email = var.member_email

--- a/tests/securityhub_cross_account/main.tf
+++ b/tests/securityhub_cross_account/main.tf
@@ -1,22 +1,34 @@
 # Provider to use as the securityhub member (aka invitee)
 provider "aws" {
   region  = "us-east-1"
-  alias   = "invitee"
   profile = "aws" # Profile must exist in your .aws/config
 }
 
 # Provider to use as the securityhub administrator
 provider "aws" {
   region  = "us-east-1"
+  alias   = "admin"
   profile = "awsalternate" # Profile must exist in your .aws/config
+}
+
+# Enables/configures Security Hub in administrator account
+module "securityhub_owner" {
+  source = "../../"
+
+  providers = {
+    aws = aws.admin
+  }
 }
 
 module "securityhub" {
   source = "../../modules/cross-account-member"
 
   providers = {
-    aws.invitee = aws.invitee
+    aws.admin = aws.admin
   }
+
+  # Without the following line it takes two attepts to destroy the resources created by the test
+  depends_on = [module.securityhub_owner]
 
   member_email = var.member_email
 

--- a/tests/securityhub_cross_account/prereq/main.tf
+++ b/tests/securityhub_cross_account/prereq/main.tf
@@ -1,8 +1,0 @@
-provider "aws" {
-  region  = "us-east-1"
-  profile = "resource-owner"
-}
-
-module "securityhub_owner" {
-  source = "../../../"
-}


### PR DESCRIPTION
Update to use new configuration_aliases tag.  Also updated to use the test framework construct for AWS profile names.  Fixed an issue with the cross-account-test and simplified it.  Added depends_on blocks to ensure the member and administrator security hub accounts were created before trying to create a member or invitee.  